### PR TITLE
Invisible chars (:listchars :list)

### DIFF
--- a/colors/railscasts.vim
+++ b/colors/railscasts.vim
@@ -126,3 +126,7 @@ hi link htmlEndTag           xmlEndTag
 hi xmlTag                    guifg=#E8BF6A
 hi xmlTagName                guifg=#E8BF6A
 hi xmlEndTag                 guifg=#E8BF6A
+
+" Invisible chars
+hi SpecialKey     guifg=#777777 guibg=NONE
+hi NonText        guifg=#777777 guibg=NONE


### PR DESCRIPTION
Just a small fix reusing the themes color for the invisible chars in vim, otherwise they appeared cyan-colored.
