### PR TITLE
Refactoring for easier palette definition

### DIFF
--- a/colors/railscasts.vim
+++ b/colors/railscasts.vim
@@ -17,131 +17,190 @@ if exists("syntax_on")
 endif
 let g:colors_name = "railscasts"
 
-hi Normal                    guifg=#e4e4e4 guibg=#121212 ctermfg=254 ctermbg=233
-hi Search                    guifg=#000000 guibg=#5f5f87 ctermfg=0 ctermbg=60 cterm=NONE
-hi Visual                    guibg=#5f5f87 ctermbg=60
-hi LineNr                    guifg=#666666 ctermfg=242
-hi Cursor                    guifg=#000000 guibg=#FFFFFF ctermfg=0 ctermbg=15
-hi CursorLine                guibg=#1c1c1c gui=NONE ctermbg=234 cterm=NONE
-hi CursorLineNr              guifg=#a9a8a8 gui=NONE ctermfg=248 cterm=NONE
-hi ColorColumn               guibg=#1c1c1c ctermbg=234
+let s:pallete = {
+      \ 'black':        {'gui': '#000000', 'cterm': 0},
+      \ 'red':          {'gui': '#ff0000', 'cterm': 1},
+      \ 'purple':       {'gui': '#800000', 'cterm': 5},
+      \ 'lightred':     {'gui': '#ff0000', 'cterm': 9},
+      \ 'darkgreen':    {'gui': '#005f00', 'cterm': 22},
+      \ 'darkgreen_1':  {'gui': '#005f5f', 'cterm': 23},
+      \ 'darkblue':     {'gui': '#005fdf', 'cterm': 26},
+      \ 'green':        {'gui': '#008700', 'cterm': 28},
+      \ 'lightblue':    {'gui': '#00ffff', 'cterm': 51},
+      \ 'bloodred':     {'gui': '#5f0000', 'cterm': 52},
+      \ 'lightpurple':  {'gui': '#5f5f87', 'cterm': 60},
+      \ 'lightblue_1':  {'gui': '#5fafaf', 'cterm': 73},
+      \ 'brightgreen':  {'gui': '#5fff00', 'cterm': 82},
+      \ 'darkred':      {'gui': '#870000', 'cterm': 88},
+      \ 'darkpurple':   {'gui': '#870087', 'cterm': 90},
+      \ 'lightpurple_1':{'gui': '#8787ff', 'cterm': 105},
+      \ 'lightgreen':   {'gui': '#87af5f', 'cterm': 107},
+      \ 'lightgreen_1': {'gui': '#87d7af', 'cterm': 115},
+      \ 'darkorange':   {'gui': '#af5f00', 'cterm': 130},
+      \ 'darkorange_1': {'gui': '#af5f5f', 'cterm': 131},
+      \ 'lightbrown':   {'gui': '#af875f', 'cterm': 137},
+      \ 'orange':       {'gui': '#df0000', 'cterm': 160},
+      \ 'darkpink':     {'gui': '#df5f5f', 'cterm': 167},
+      \ 'darkpink_1':   {'gui': '#df5f87', 'cterm': 168},
+      \ 'darkyellow':   {'gui': '#dfaf5f', 'cterm': 179},
+      \ 'lightpink':    {'gui': '#dfdfff', 'cterm': 189},
+      \ 'lightorange':  {'gui': '#ff8700', 'cterm': 208},
+      \ 'lightpink_1':  {'gui': '#ffaf87', 'cterm': 216},
+      \ 'yellow':       {'gui': '#ffdf5f', 'cterm': 221},
+      \ 'bg':           {'gui': '#121212', 'cterm': 233},
+      \ 'bg_1':         {'gui': '#1c1c1c', 'cterm': 234},
+      \ 'bg_2':         {'gui': '#303030', 'cterm': 236},
+      \ 'bg_3':         {'gui': '#3a3a3a', 'cterm': 237},
+      \ 'darkgray':     {'gui': '#444444', 'cterm': 238},
+      \ 'darkgray_1':   {'gui': '#585858', 'cterm': 240},
+      \ 'gray':         {'gui': '#606060', 'cterm': 241},
+      \ 'gray_1':       {'gui': '#666666', 'cterm': 242},
+      \ 'gray_2':       {'gui': '#767676', 'cterm': 243},
+      \ 'lightgray':    {'gui': '#a8a8a8', 'cterm': 248},
+      \ 'off_white':    {'gui': '#e4e4e4', 'cterm': 254},
+      \ 'white':        {'gui': '#ffffff', 'cterm': 255},
+      \ 'NONE':         {'gui': 'NONE',    'cterm': 'NONE'},
+      \}
+
+function! s:colors(...)
+  if !a:0 || a:0 > 3 | return {} | endif
+  if a:0 == 1 && has_key(s:pallete, a:1)
+    let fg = s:pallete[a:1]
+    return {'guifg': fg.gui, 'ctermfg': fg.cterm}
+  elseif a:0 == 2
+    let col = {}
+    if has_key(s:pallete, a:1)
+      let fg = s:pallete[a:1]
+      if has_key(fg, 'gui') | let col['guifg'] = fg['gui'] | endif
+      if has_key(fg, 'cterm') | let col['ctermfg'] = fg['cterm'] | endif
+    endif
+    if has_key(s:pallete, a:2)
+      let bg = s:pallete[a:2]
+      if has_key(bg, 'gui') | let col['guibg'] = bg['gui'] | endif
+      if has_key(bg, 'cterm') | let col['ctermbg'] = bg['cterm'] | endif
+    endif
+    return col
+  elseif a:0 == 3 && !empty(a:3)
+    return extend(s:colors(a:1, a:2), {'gui': a:3, 'cterm': a:3})
+  endif
+endfunction
+
+function! s:stringify(col_dict)
+  return join(map(items(a:col_dict), "join(v:val, '=')"))
+endfunction
+
+function! s:Hi(group, ...)
+  let colors = call('s:colors', a:000)
+  execute 'hi' a:group s:stringify(colors)
+endfunction
+
+call s:Hi('Normal', 'off_white', 'bg')
+call s:Hi('Search', 'black', 'lightpurple')
+call s:Hi('Visual', '', 'lightpurple')
+call s:Hi('LineNr', 'gray_1')
+call s:Hi('Cursor', 'black', 'white')
+call s:Hi('CursorLine', '', 'bg_1', 'NONE')
+call s:Hi('CursorLineNr', 'lightgray', '', 'NONE')
+call s:Hi('ColorColumn', '', 'bg_1', 'NONE')
 hi! link CursorColumn ColorColumn
-hi VertSplit                 guifg=#444444 guibg=#121212 gui=NONE ctermfg=238 ctermbg=233 cterm=NONE
-hi SignColumn                guifg=#FFFFFF guibg=NONE ctermfg=15 ctermbg=NONE
+
+call s:Hi('VertSplit', 'darkgray', 'bg', 'NONE')
+call s:Hi('SignColumn', 'white', 'NONE')
 
 " StatusLine
-" Bold
-hi User1                     guifg=#eeeeee guibg=#606060 gui=bold ctermfg=255 ctermbg=241 cterm=bold
-" Yellow
-hi User2                     guifg=#FFAF00 guibg=#606060 gui=bold ctermfg=214 ctermbg=241 cterm=bold
-" Green
-hi User3                     guifg=#5fff00 guibg=#606060 gui=bold ctermfg=82 ctermbg=241 cterm=bold
-" Red
-hi User4                     guifg=#870000 guibg=#606060 gui=bold ctermfg=88 ctermbg=241 cterm=bold
-hi User5                     guifg=#e4e4e4 guibg=#606060 gui=bold ctermfg=254 ctermbg=241 cterm=bold
-hi User6                     guifg=#e4e4e4 guibg=#606060 gui=bold ctermfg=254 ctermbg=241 cterm=bold
-hi User7                     guifg=#e4e4e4 guibg=#606060 gui=bold ctermfg=254 ctermbg=241 cterm=bold
-hi User8                     guifg=#e4e4e4 guibg=#606060 gui=bold ctermfg=254 ctermbg=241 cterm=bold
-hi User9                     guifg=#e4e4e4 guibg=#606060 gui=bold ctermfg=254 ctermbg=241 cterm=bold
-hi StatusLine                guifg=#e4e4e4 guibg=#606060 gui=NONE ctermfg=254 ctermbg=241 cterm=NONE
-hi StatusLineNC              guifg=#585858 guibg=#303030 gui=NONE ctermfg=240 ctermbg=236 cterm=NONE
+" ----------
+call s:Hi('StatusLine', 'off_white', 'gray', 'NONE')
+call s:Hi('StatusLineNC', 'darkgray_1', 'bg_2', 'NONE')
 
 " Folds
 " -----
-" line used for closed folds
-hi Folded                    guifg=#ffffff guibg=#444444 gui=NONE ctermfg=15 ctermbg=238 cterm=NONE
+call s:Hi('Folded', 'white', 'darkgray', 'NONE')
 hi! link FoldColumn SignColumn
 
 " Invisible Characters
 " ------------------
-hi NonText                   guifg=#767676 gui=NONE cterm=NONE ctermfg=243
-hi SpecialKey                guifg=#767676 gui=NONE cterm=NONE ctermfg=243
+call s:Hi('NonText', 'gray_2', '', 'NONE')
+call s:Hi('SpecialKey', 'gray_2', '', 'NONE')
 
 " Misc
 " ----
 " directory names and other special names in listings
-hi Directory                 guifg=#87af5f gui=NONE ctermfg=107 cterm=NONE
+call s:Hi('Directory', 'lightgreen', '', 'NONE')
 
 " Popup Menu
 " ----------
-" normal item in popup
-hi Pmenu                     guifg=#ffffff guibg=#444444 gui=NONE ctermfg=15 ctermbg=238 cterm=NONE
-" selected item in popup
-hi PmenuSel                  guifg=#000000 guibg=#87af5f gui=NONE ctermfg=0 ctermbg=107 cterm=NONE
-" scrollbar in popup
-hi PMenuSbar                 guibg=#5A647E gui=NONE ctermfg=15 ctermbg=60 cterm=NONE
-" thumb of the scrollbar in the popup
-hi PMenuThumb                guifg=#ffffff guibg=#a8a8a8 gui=NONE ctermfg=15 ctermbg=248 cterm=NONE
+call s:Hi('Pmenu', 'white', 'darkgray', 'NONE')
+call s:Hi('PmenuSel', 'black', 'lightgreen', 'NONE')
+call s:Hi('PMenuSbar', 'white', 'lightpurple', 'NONE')
+call s:Hi('PMenuThumb', 'white', 'lightgray', 'NONE')
 
 " Code constructs
 " ---------------
-hi Comment                   guifg=#af875f ctermfg=137
-hi Todo                      guifg=#df5f5f guibg=NONE gui=bold ctermfg=167 ctermbg=NONE cterm=bold
-" hi Todo                      guifg=#000000 guibg=ffff00 gui=bold ctermfg=16 ctermbg=11 cterm=bold
-hi Constant                  guifg=#6D9CBE ctermfg=73
-hi Error                     guifg=#FFFFFF guibg=#990000 ctermfg=221 ctermbg=88
-hi WarningMsg                guifg=#800000 guibg=NONE ctermfg=1 ctermbg=NONE
-hi Identifier                guifg=#af5f5f gui=NONE ctermfg=221 cterm=NONE
-hi Keyword                   guifg=#af5f00 gui=NONE ctermfg=130 cterm=NONE
-hi Number                    guifg=#87af5f ctermfg=107
-hi Statement                 guifg=#af5f00 gui=NONE ctermfg=130 cterm=NONE
-hi String                    guifg=#87af5f ctermfg=107
-hi Title                     guifg=#FFFFFF ctermfg=15
-hi Type                      guifg=#df5f5f gui=NONE ctermfg=167 cterm=NONE
-hi PreProc                   guifg=#ff8700 ctermfg=208
-hi Special                   guifg=#005f00 ctermfg=22
+call s:Hi('Comment', 'lightbrown')
+call s:Hi('Todo', 'darkpink', 'NONE', 'bold')
+call s:Hi('Constant', 'lightblue_1')
+call s:Hi('Error', 'yellow', 'darkred')
+call s:Hi('WarningMsg', 'purple', 'NONE')
+call s:Hi('Identifier', 'yellow', '', 'NONE')
+call s:Hi('Keyword', 'darkorange', '', 'NONE')
+call s:Hi('Number', 'lightgreen')
+call s:Hi('Statement', 'darkorange', '', 'NONE')
+call s:Hi('String', 'lightgreen')
+call s:Hi('Title', 'white')
+call s:Hi('Type', 'darkpink')
+call s:Hi('PreProc', 'lightorange')
+call s:Hi('Special', 'darkgreen')
 
 " Diffs
 " -----
-hi DiffAdd                   guifg=#e4e4e4 guibg=#519F50 ctermfg=254 ctermbg=22
-hi DiffDelete                guifg=#000000 guibg=#660000 gui=bold ctermfg=16 ctermbg=52 cterm=bold
-hi DiffChange                guifg=#FFFFFF guibg=#870087 ctermfg=15 ctermbg=90
-hi DiffText                  guifg=#FFFFFF guibg=#FF0000 gui=bold ctermfg=15 ctermbg=9 cterm=bold
+call s:Hi('DiffAdd', 'off_white', 'darkgreen')
+call s:Hi('DiffDelete', 'black', 'bloodred')
+call s:Hi('DiffChange', 'white', 'darkpurple')
+call s:Hi('DiffText', 'white', 'lightred')
 
-hi diffAdded                 guifg=#008700 ctermfg=28
-hi diffRemoved               guifg=#800000 ctermfg=1
-hi diffNewFile               guifg=#FFFFFF guibg=NONE gui=bold ctermfg=15 ctermbg=NONE cterm=bold
-hi diffFile                  guifg=#FFFFFF guibg=NONE gui=bold ctermfg=15 ctermbg=NONE cterm=bold
-
+call s:Hi('diffAdded', 'green')
+call s:Hi('diffRemoved', 'red')
+call s:Hi('diffNewFile', 'white', 'NONE', 'bold')
+call s:Hi('diffFile', 'white', 'NONE', 'bold')
 
 " Ruby
 " ----
-hi rubyTodo                  guifg=#df5f5f guibg=NONE gui=bold ctermfg=167 ctermbg=NONE cterm=bold
-hi rubyClass                 guifg=#FFFFFF ctermfg=15
-hi rubyConstant              guifg=#df5f5f ctermfg=167
-hi rubyInterpolation         guifg=#FFFFFF ctermfg=15
-hi rubyBlockParameter        guifg=#dfdfff ctermfg=189
-hi rubyPseudoVariable        guifg=#ffdf5f ctermfg=221
-hi rubyStringDelimiter       guifg=#87af5f ctermfg=107
-hi rubyInstanceVariable      guifg=#dfdfff ctermfg=189
-hi rubyPredefinedConstant    guifg=#df5f5f ctermfg=167
-hi rubyLocalVariableOrMethod guifg=#dfdfff ctermfg=189
+call s:Hi('rubyTodo', 'darkpink', 'NONE', 'bold')
+call s:Hi('rubyClass', 'white')
+call s:Hi('rubyConstant', 'darkpink')
+call s:Hi('rubyInterpolation', 'white')
+call s:Hi('rubyBlockParameter', 'lightpink')
+call s:Hi('rubyPseudoVariable', 'yellow')
+call s:Hi('rubyStringDelimiter', 'lightgreen')
+call s:Hi('rubyInstanceVariable', 'lightpink')
+call s:Hi('rubyPredefinedConstant', 'darkpink')
+call s:Hi('rubyLocalVariableOrMethod', 'lightpink')
 
 " Python
 " ------
-hi pythonExceptions          guifg=#ffaf87 ctermfg=216
-hi pythonDoctest             guifg=#8787ff ctermfg=105
-hi pythonDoctestValue        guifg=#87d7af ctermfg=115
+call s:Hi('pythonExceptions', 'lightpink_1')
+call s:Hi('pythonDoctest', 'lightpurple_1')
+call s:Hi('pythonDoctestValue', 'lightgreen_1')
 
 " Mail
 " ----
-hi mailEmail                 guifg=#87af5f ctermfg=107 gui=italic cterm=underline
-hi mailHeaderKey             guifg=#ffdf5f ctermfg=221
+call s:Hi('mailEmail', 'lightgreen', '', 'italic')
+call s:Hi('mailHeaderKey', 'yellow')
 hi! link mailSubject mailHeaderKey
 
 " Spell
 " ----
-hi SpellBad                  guifg=#D70000 guibg=NONE gui=undercurl ctermfg=160 ctermbg=NONE cterm=underline
-hi SpellRare                 guifg=#df5f87 guibg=NONE gui=underline ctermfg=168 ctermbg=NONE cterm=underline
-hi SpellCap                  guifg=#dfdfff guibg=NONE gui=underline ctermfg=189 ctermbg=NONE cterm=underline
-hi SpellLocal                guifg=#00FFFF guibg=NONE gui=undercurl ctermfg=51 ctermbg=NONE cterm=underline
-hi MatchParen                guifg=#FFFFFF guibg=#005f5f ctermfg=15 ctermbg=23
+call s:Hi('SpellBad', 'orange', 'NONE', 'undercurl')
+call s:Hi('SpellRare', 'darkpink_1', 'NONE', 'underline')
+call s:Hi('SpellCap', 'lightpink', 'NONE', 'underline')
+call s:Hi('SpellLocal', 'lightblue', 'NONE', 'undercurl')
+call s:Hi('MatchParen', 'white', 'darkgreen_1')
 
 " XML
 " ---
-hi xmlTag                    guifg=#dfaf5f ctermfg=179
-hi xmlTagName                guifg=#dfaf5f ctermfg=179
-hi xmlEndTag                 guifg=#dfaf5f ctermfg=179
+call s:Hi('xmlTag', 'darkyellow')
+call s:Hi('xmlTagName', 'darkyellow')
+call s:Hi('xmlEndTag', 'darkyellow')
 
 " HTML
 " ----
@@ -149,6 +208,8 @@ hi! link htmlTag              xmlTag
 hi! link htmlTagName          xmlTagName
 hi! link htmlEndTag           xmlEndTag
 
-hi checkbox guifg=#3a3a3a guibg=NONE gui=NONE ctermfg=237 ctermbg=NONE cterm=NONE
-hi checkboxDone guifg=#5fff00 guibg=NONE gui=BOLD ctermfg=82 ctermbg=NONE cterm=BOLD
-hi checkboxNotDone guifg=#005fdf guibg=NONE gui=BOLD ctermfg=26 ctermbg=NONE cterm=BOLD
+" Checkbox
+" --------
+call s:Hi('checkbox', 'bg_3', 'NONE', 'NONE')
+call s:Hi('checkboxDone', 'brightgreen', 'NONE', 'bold')
+call s:Hi('checkboxNotDone', 'darkblue', 'NONE', 'bold')


### PR DESCRIPTION
I have refactored the definitions in an attempt to create a more scalable palette definition style.
A bunch of these color names are placeholders and would most likely need changing and relooking, some of them might need removing altogether.

Lets use this PR to discuss and take this further towards a much better colorscheme definition for vim.