### PR TITLE
Support for lightline.vim

### DIFF
--- a/colors/railscasts.vim
+++ b/colors/railscasts.vim
@@ -40,6 +40,43 @@ hi User9                     guifg=#e4e4e4 guibg=#606060 gui=bold ctermfg=254 ct
 hi StatusLine                guifg=#e4e4e4 guibg=#606060 gui=NONE ctermfg=254 ctermbg=241 cterm=NONE
 hi StatusLineNC              guifg=#585858 guibg=#303030 gui=NONE ctermfg=240 ctermbg=236 cterm=NONE
 
+"lightline.vim
+
+let s:base03  = [ '#151513', 233 ]
+let s:base02  = [ '#30302c ', 236 ]
+let s:base01  = [ '#4e4e43', 239 ]
+let s:base00  = [ '#666656', 242  ]
+let s:base0   = [ '#808070', 244 ]
+let s:base1   = [ '#949484', 246 ]
+let s:base2   = [ '#a8a897', 248 ]
+let s:base3   = [ '#e8e8d3', 253 ]
+let s:yellow  = [ '#ff8700', 214 ]
+let s:orange  = [ '#fad07a', 222 ]
+let s:red     = [ '#df5f5f', 167 ]
+let s:magenta = [ '#ff8700', 214 ]
+let s:blue    = [ '#6d9cbe', 103 ]
+let s:cyan    = [ '#8fbfdc', 110 ]
+let s:green   = [ '#87af5f', 107  ]
+
+let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
+let s:p.normal.left = [ [ s:base02, s:blue ], [ s:base3, s:base01 ] ]
+let s:p.normal.right = [ [ s:base02, s:base1 ], [ s:base2, s:base01 ] ]
+let s:p.inactive.right = [ [ s:base02, s:base00 ], [ s:base0, s:base02 ] ]
+let s:p.inactive.left =  [ [ s:base0, s:base02 ], [ s:base00, s:base02 ] ]
+let s:p.insert.left = [ [ s:base02, s:green ], [ s:base3, s:base01 ] ]
+let s:p.replace.left = [ [ s:base02, s:red ], [ s:base3, s:base01 ] ]
+let s:p.visual.left = [ [ s:base02, s:magenta ], [ s:base3, s:base01 ] ]
+let s:p.normal.middle = [ [ s:base0, s:base02 ] ]
+let s:p.inactive.middle = [ [ s:base00, s:base02 ] ]
+let s:p.tabline.left = [ [ s:base3, s:base00 ] ]
+let s:p.tabline.tabsel = [ [ s:base3, s:base02 ] ]
+let s:p.tabline.middle = [ [ s:base01, s:base1 ] ]
+let s:p.tabline.right = copy(s:p.normal.right)
+let s:p.normal.error = [ [ s:red, s:base02 ] ]
+let s:p.normal.warning = [ [ s:yellow, s:base01 ] ]
+
+let g:lightline#colorscheme#railscasts#palette = lightline#colorscheme#flatten(s:p)
+
 " Folds
 " -----
 " line used for closed folds


### PR DESCRIPTION
hi!
This is nice colorscheme, but this colorscheme is not colorize [lightline.vim](https://github.com/itchyny/lightline.vim) .
I want to support it.

![railscasts](https://cloud.githubusercontent.com/assets/19149156/15452483/d02a31d8-202a-11e6-915e-5ecad1513379.jpg)
